### PR TITLE
Support for internal JSON refs

### DIFF
--- a/json-simple-schema-tests.js
+++ b/json-simple-schema-tests.js
@@ -88,7 +88,11 @@ var packageJsonSchemaWithInternalRef = {
 	'properties': {
 		'prop': {'$ref': '#/definitions/definitionWithSpecialChars~0~1%25'},
 		'prop2': {'$ref': '#/definitions/arrayOfDefs/1'},
-		'prop3': {'$ref': '#'}
+		'prop3': {'$ref': '#'},
+		'refItems': {
+			'type': 'array',
+			'items': {'$ref': '#/definitions/arrayOfDefs/1'}
+		}
 	},
 	'definitions': {
 		'definitionWithSpecialChars~/%': {
@@ -115,4 +119,7 @@ Tinytest.add('JSONSchema - convert a JSON schema object with internal references
 	test.equal(rawSchema.prop.regEx, SimpleSchema.RegEx.Email);
 	test.equal(rawSchema.prop2.type, Number);
 	test.equal(rawSchema.prop3.type, Object);
+
+	test.equal(rawSchema.refItems.type, Array);
+	test.equal(rawSchema['refItems.$'].type, Number);
 });

--- a/json-simple-schema-tests.js
+++ b/json-simple-schema-tests.js
@@ -92,7 +92,8 @@ var packageJsonSchemaWithInternalRef = {
 	},
 	'definitions': {
 		'definitionWithSpecialChars~/%': {
-			'type': 'boolean'
+			'type': 'string',
+			'format': 'email'
 		},
 		'arrayOfDefs': [
 			{'type': 'string'},
@@ -110,7 +111,8 @@ Tinytest.add('JSONSchema - convert a JSON schema object with internal references
 
 	var rawSchema = simpleSchema._schema;
 
-	test.equal(rawSchema.prop.type, Boolean);
+	test.equal(rawSchema.prop.type, String);
+	test.equal(rawSchema.prop.regEx, SimpleSchema.RegEx.Email);
 	test.equal(rawSchema.prop2.type, Number);
 	test.equal(rawSchema.prop3.type, Object);
 });

--- a/json-simple-schema.js
+++ b/json-simple-schema.js
@@ -38,7 +38,6 @@ JSONSchema = function(schema, options) {
 	}
 
 	function getTypeFromProperty(prop) {
-
 		var propType = prop.type === 'array' ? prop.items.type : prop.type;
 		var format = prop.format;
 		var ssType = String;
@@ -67,7 +66,6 @@ JSONSchema = function(schema, options) {
 	}
 
 	function getSubPropertiesFromProperty(prop) {
-
 		if (prop.type === 'object' && prop.properties) {
 			return prop.properties;
 		} else if (prop.type === 'array' && prop.items && prop.items.type === 'object' && prop.items.properties) {
@@ -78,7 +76,6 @@ JSONSchema = function(schema, options) {
 	}
 
 	function getRequiredFromProperty(prop) {
-
 		if (prop.type === 'object' && prop.properties) {
 			return prop.required || [];
 		} else if (prop.type === 'array' && prop.items && prop.items.type === 'object' && prop.items.properties) {
@@ -164,13 +161,16 @@ JSONSchema = function(schema, options) {
 						return memo[refPart];
 					}
 				}, jsonSchema);
-				return out;
+				return resolveReference(out);
 			}
 			else {
 				throw new Error("Non-internal or relative JSON references not yet implemented")
 			}
 		}
 		else {
+			if (prop.items && prop.items.$ref) {
+				return _.defaults({items: resolveReference(prop.items)}, prop);
+			}
 			return prop;
 		}
 	}

--- a/json-simple-schema.js
+++ b/json-simple-schema.js
@@ -17,6 +17,8 @@ JSONSchema = function(schema, options) {
 		var schema = {};
 
 		_.each(properties, function(prop, key) {
+			prop = resolveReference(prop);
+
 			var ssProp = {};
 			addRules(ssProp, prop, required.indexOf(key) !== -1);
 			schema[key] = ssProp;
@@ -36,7 +38,6 @@ JSONSchema = function(schema, options) {
 	}
 
 	function getTypeFromProperty(prop) {
-		prop = resolveReference(prop);
 
 		var propType = prop.type === 'array' ? prop.items.type : prop.type;
 		var format = prop.format;
@@ -66,7 +67,6 @@ JSONSchema = function(schema, options) {
 	}
 
 	function getSubPropertiesFromProperty(prop) {
-		prop = resolveReference(prop);
 
 		if (prop.type === 'object' && prop.properties) {
 			return prop.properties;
@@ -78,7 +78,6 @@ JSONSchema = function(schema, options) {
 	}
 
 	function getRequiredFromProperty(prop) {
-		prop = resolveReference(prop);
 
 		if (prop.type === 'object' && prop.properties) {
 			return prop.required || [];


### PR DESCRIPTION
Internal JSON refs are fully tested and in accordance with https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-04 .

Remote JSON refs not yet supported - we'd need to either preload them since this algorithm is synchronous, and that changes the external API, so that's a longer conversation I think. They're not crucial for my use case, but if there's any demand I can take a look.

This code will be used in production, so I'll be maintaining any bugs that pop up!

(Changes licensed under MIT.)
