### PR TITLE
refactor to allow creating our own instance of SimpleSchema

### DIFF
--- a/json-simple-schema.js
+++ b/json-simple-schema.js
@@ -8,10 +8,14 @@ JSONSchema = function(schema, options) {
 
 	var jsonSchema = schema;
 
-	this.toSimpleSchema = function toSimpleSchema() {
+	this.toSimpleSchemaProps = function toSimpleSchemaProps() {
 		var props = jsonSchema.properties || jsonSchema;
-		var simpleSchema = translateProperties(props, getRequiredFromProperty(jsonSchema));
-		return new SimpleSchema(simpleSchema);
+		return translateProperties(props, getRequiredFromProperty(jsonSchema));
+	}
+
+	this.toSimpleSchema = function toSimpleSchema() {
+		var simpleSchemaProps = this.toSimpleSchemaProps();
+		return new SimpleSchema(simpleSchemaProps);
 	}
 
 	function translateProperties(properties, required) {


### PR DESCRIPTION
Hi, I've adding additional properties for SimpleSchema beyond those automatically added from json-simple-schema by using `.toSimpleSchemaProps()`, which I add in this PR. I thought this might also be useful for others, so I'm submitting it for your consideration.
